### PR TITLE
fix(markdown): table cells don't parse rich text formatting (#2)

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -339,6 +339,58 @@ describe('markdownToBlocks', () => {
       expect(dataCells[0][0].text.content).toBe('key')
       expect(dataCells[1][0].text.content).toBe('42')
     })
+
+    it('should parse bold text in table cells', () => {
+      const md = '| Header |\n| --- |\n| **bold** |'
+      const blocks = markdownToBlocks(md)
+      const cell = blocks[0].table.children[1].table_row.cells[0]
+      expect(cell).toHaveLength(1)
+      expect(cell[0].text.content).toBe('bold')
+      expect(cell[0].annotations.bold).toBe(true)
+    })
+
+    it('should parse italic text in table cells', () => {
+      const md = '| Header |\n| --- |\n| *italic* |'
+      const blocks = markdownToBlocks(md)
+      const cell = blocks[0].table.children[1].table_row.cells[0]
+      expect(cell[0].text.content).toBe('italic')
+      expect(cell[0].annotations.italic).toBe(true)
+    })
+
+    it('should parse inline code in table cells', () => {
+      const md = '| Header |\n| --- |\n| `code` |'
+      const blocks = markdownToBlocks(md)
+      const cell = blocks[0].table.children[1].table_row.cells[0]
+      expect(cell[0].text.content).toBe('code')
+      expect(cell[0].annotations.code).toBe(true)
+    })
+
+    it('should parse links in table cells', () => {
+      const md = '| Header |\n| --- |\n| [click](https://example.com) |'
+      const blocks = markdownToBlocks(md)
+      const cell = blocks[0].table.children[1].table_row.cells[0]
+      expect(cell[0].text.content).toBe('click')
+      expect(cell[0].text.link).toEqual({ url: 'https://example.com' })
+    })
+
+    it('should parse mixed formatting in table cells', () => {
+      const md = '| Header |\n| --- |\n| **bold** and *italic* |'
+      const blocks = markdownToBlocks(md)
+      const cell = blocks[0].table.children[1].table_row.cells[0]
+      // Should have multiple rich text segments
+      expect(cell.length).toBeGreaterThan(1)
+      const boldSegment = cell.find((rt: any) => rt.annotations?.bold)
+      expect(boldSegment).toBeDefined()
+      expect(boldSegment.text.content).toBe('bold')
+    })
+
+    it('should parse rich text in header cells', () => {
+      const md = '| **Bold Header** |\n| --- |\n| data |'
+      const blocks = markdownToBlocks(md)
+      const headerCell = blocks[0].table.children[0].table_row.cells[0]
+      expect(headerCell[0].text.content).toBe('Bold Header')
+      expect(headerCell[0].annotations.bold).toBe(true)
+    })
   })
 
   describe('images', () => {

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -859,7 +859,7 @@ function createTable(headers: string[], rows: string[][], hasHeader: boolean): N
     object: 'block',
     type: 'table_row',
     table_row: {
-      cells: headers.map((h) => [createRichText(h)])
+      cells: headers.map((h) => parseRichText(h))
     }
   })
 
@@ -867,7 +867,7 @@ function createTable(headers: string[], rows: string[][], hasHeader: boolean): N
   for (const row of rows) {
     const cells = []
     for (let c = 0; c < tableWidth; c++) {
-      cells.push([createRichText(row[c] || '')])
+      cells.push(parseRichText(row[c] || ''))
     }
     allRows.push({
       object: 'block',


### PR DESCRIPTION
Closes #2

## Summary

`createTable()` in `markdown.ts` used `createRichText()` for table cell content, which creates plain text. Markdown formatting markers (`**bold**`, `*italic*`, etc.) were stored as literal characters instead of being parsed into Notion rich_text annotations.

Fix: swap `createRichText()` for `parseRichText()` on two lines (header cells and data cells).

## Test plan

### Unit tests (6 new, 950 total pass)
1. Bold text in data cells - verify `annotations.bold: true`
2. Italic text in cells - verify `annotations.italic: true`
3. Inline code in cells - verify `annotations.code: true`
4. Links in cells - verify `text.link` is set
5. Mixed formatting in one cell - verify multiple rich_text segments
6. Bold text in header cells - verify header row also parses formatting

### Integration tests against live Notion (production MCP)
- Created test page under sandbox with 6 tables: bold, italic, code, links, mixed, plain text
- Notion API accepted all tables without errors
- Read back table rows via `blocks.children` - confirmed production MCP stores `**bold**` as literal text (bug confirmed)
- Unit tests verify that `parseRichText()` correctly produces `annotations.bold: true` for `**bold**` input
- Notion API already accepts rich_text with annotations in all other block types (headings, paragraphs, lists)
- Test page archived after verification