### PR TITLE
fix(properties): handle relation type in convertToNotionProperties (#4)

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -206,6 +206,98 @@ describe('convertToNotionProperties', () => {
     })
   })
 
+  describe('relation values with schema', () => {
+    it('converts a single page ID string to relation format', () => {
+      const result = convertToNotionProperties({ Project: 'abc123def456' }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def456' }] }
+      })
+    })
+
+    it('converts a UUID string to relation format', () => {
+      const result = convertToNotionProperties(
+        { Project: '12345678-1234-1234-1234-123456789abc' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: '12345678-1234-1234-1234-123456789abc' }] }
+      })
+    })
+
+    it('converts a Notion URL to relation format by extracting the page ID', () => {
+      const result = convertToNotionProperties(
+        { Project: 'https://www.notion.so/My-Page-abc123def45678901234567890abcdef' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def45678901234567890abcdef' }] }
+      })
+    })
+
+    it('converts a Notion URL with query params to relation format', () => {
+      const result = convertToNotionProperties(
+        { Project: 'https://www.notion.so/workspace/abc123def45678901234567890abcdef?v=xyz' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def45678901234567890abcdef' }] }
+      })
+    })
+
+    it('converts an array of page ID strings to relation format', () => {
+      const result = convertToNotionProperties({ Projects: ['abc123', 'def456'] }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [{ id: 'abc123' }, { id: 'def456' }] }
+      })
+    })
+
+    it('converts an array of Notion URLs to relation format', () => {
+      const result = convertToNotionProperties(
+        {
+          Projects: [
+            'https://www.notion.so/Page-A-abc123def45678901234567890abcdef',
+            'https://www.notion.so/Page-B-fedcba09876543210987654321fedcba'
+          ]
+        },
+        { Projects: 'relation' }
+      )
+      expect(result).toEqual({
+        Projects: {
+          relation: [{ id: 'abc123def45678901234567890abcdef' }, { id: 'fedcba09876543210987654321fedcba' }]
+        }
+      })
+    })
+
+    it('converts a JSON array string to relation format', () => {
+      const result = convertToNotionProperties({ Projects: '["abc123", "def456"]' }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [{ id: 'abc123' }, { id: 'def456' }] }
+      })
+    })
+
+    it('converts empty string to empty relation array', () => {
+      const result = convertToNotionProperties({ Project: '' }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [] }
+      })
+    })
+
+    it('converts empty array to empty relation', () => {
+      const result = convertToNotionProperties({ Projects: [] }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [] }
+      })
+    })
+
+    it('passes through pre-formatted relation objects as-is', () => {
+      const value = { relation: [{ id: 'abc123' }] }
+      const result = convertToNotionProperties({ Project: value }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: value
+      })
+    })
+  })
+
   describe('mixed properties with schema', () => {
     it('converts multiple property types in a single call', () => {
       const properties = {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -5,6 +5,37 @@
 
 import * as RichText from './richtext.js'
 
+/** Extract a 32-char hex page ID from a Notion URL, or return the input as-is if it's already a raw ID */
+function extractPageId(value: string): string {
+  const match = value.match(/([a-f0-9]{32})/)
+  if (match) return match[1]
+  // Also accept hyphenated UUIDs as-is
+  return value
+}
+
+/** Convert a single string or array value to Notion relation format */
+function toRelation(value: any): { relation: { id: string }[] } {
+  if (typeof value === 'string') {
+    if (value === '') return { relation: [] }
+    // Try parsing as JSON array (e.g. '["id1", "id2"]')
+    if (value.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(value)
+        if (Array.isArray(parsed)) {
+          return { relation: parsed.map((v: string) => ({ id: extractPageId(v) })) }
+        }
+      } catch {
+        // Not valid JSON, treat as single value
+      }
+    }
+    return { relation: [{ id: extractPageId(value) }] }
+  }
+  if (Array.isArray(value)) {
+    return { relation: value.map((v: string) => ({ id: extractPageId(v) })) }
+  }
+  return value
+}
+
 /**
  * Convert simple property values to Notion API format
  * Handles auto-detection of property types and conversion
@@ -42,6 +73,8 @@ export function convertToNotionProperties(
         converted[key] = { email: value }
       } else if (schemaType === 'phone_number') {
         converted[key] = { phone_number: value }
+      } else if (schemaType === 'relation') {
+        converted[key] = toRelation(value)
       } else if (key === 'Name' || key === 'Title' || key.toLowerCase() === 'title') {
         // Fallback: guess title from key name
         converted[key] = { title: [RichText.text(value)] }
@@ -54,6 +87,11 @@ export function convertToNotionProperties(
     } else if (typeof value === 'boolean') {
       converted[key] = { checkbox: value }
     } else if (Array.isArray(value)) {
+      const schemaType = schema?.[key]
+      if (schemaType === 'relation') {
+        converted[key] = toRelation(value)
+        continue
+      }
       // Could be multi_select, relation, people, files
       // Only assume multi_select if all elements are strings
       if (value.length > 0 && value.every((v) => typeof v === 'string')) {


### PR DESCRIPTION
Closes #4

## Summary

- Add `relation` branch to `convertToNotionProperties()` that converts page IDs, Notion URLs, JSON array strings, and arrays to Notion API relation format
- Handles both string and array inputs when schema type is `relation`
- Extract 32-char hex page IDs from Notion URLs (`https://www.notion.so/Page-Title-abc123...`)
- Empty string/array produces `{ relation: [] }`
- Pre-formatted objects pass through as-is

## Test plan

### Phase 1: Unit tests (9 new tests, 954 total pass)

| Test case | Result |
|-----------|--------|
| Single page ID string → relation format | PASS |
| UUID string → relation format | PASS |
| Notion URL → extracts page ID → relation format | PASS |
| Notion URL with query params → extracts ID | PASS |
| Array of page IDs → relation format | PASS |
| Array of Notion URLs → relation format | PASS |
| JSON array string → relation format | PASS |
| Empty string → empty relation array | PASS |
| Empty array → empty relation | PASS |
| Pre-formatted object → pass-through | PASS |

### Phase 2: Integration tests against live Notion sandbox

| Test case | Result | Evidence |
|-----------|--------|----------|
| Bug confirmation: string value rejected by Notion | PASS (bug confirmed) | `"Related is expected to be relation."` - production MCP converts to `select` |
| Single relation `{ relation: [{ id }] }` accepted | PASS | Page created, query returns `Related: ["31c3d6a0-..."]` |
| Multi relation (2 targets) accepted | PASS | Query returns both target IDs |
| Empty relation `{ relation: [] }` accepted | PASS | Query returns `Related: []` |
| Unhyphenated 32-char ID accepted by Notion | PASS | Page created successfully |
| Round-trip: write relations → query → IDs match | PASS | All IDs match target pages |

## Note

Issue #4 also mentions `update_page` not fetching schema. That's a separate concern tracked in the issue - this PR focuses on the `convertToNotionProperties` core fix which is the prerequisite.