### PR TITLE
fix(icons): support external URLs and built-in icon shorthand (#5)

### DIFF
--- a/src/docs/databases.md
+++ b/src/docs/databases.md
@@ -75,7 +75,7 @@ Optionally specify `data_source_id` to target a specific data source (defaults t
 - `description` - Description
 - `properties` - Schema properties (for create/update data source)
 - `is_inline` - Display as inline (boolean, for create/update_database)
-- `icon` - Emoji icon (for update_database)
+- `icon` - Emoji, external URL (`https://...`), or built-in shorthand (`name:color`, e.g. `document:gray`) (for update_database)
 - `cover` - Cover image URL (for update_database)
 - `filters` / `sorts` / `limit` - Query options
 - `search` - Smart search across text fields

--- a/src/docs/pages.md
+++ b/src/docs/pages.md
@@ -64,6 +64,6 @@ Move a page to a new parent page.
 - `parent_id` - Parent page or database ID
 - `properties` - Page properties (for database pages)
 - `property_id` - Property ID (required for get_property action)
-- `icon` - Emoji icon
+- `icon` - Emoji, external URL (`https://...`), or built-in shorthand (`name:color`, e.g. `document:gray`)
 - `cover` - Cover image URL
 - `archived` - Archive status (boolean, for update action)

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -5,6 +5,7 @@
 
 import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
+import { formatIcon } from '../helpers/icons.js'
 import { autoPaginate, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
@@ -635,7 +636,7 @@ async function updateDatabaseContainer(notion: Client, input: DatabasesInput): P
   }
 
   if (input.icon) {
-    updates.icon = { type: 'emoji', emoji: input.icon }
+    updates.icon = formatIcon(input.icon)
   }
 
   if (input.cover) {

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -5,6 +5,7 @@
 
 import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
+import { formatIcon } from '../helpers/icons.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
@@ -172,7 +173,7 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
   }
 
   const pageData: any = { parent, properties }
-  if (input.icon) pageData.icon = { type: 'emoji', emoji: input.icon }
+  if (input.icon) pageData.icon = formatIcon(input.icon)
   if (input.cover) {
     if (!isSafeUrl(input.cover)) {
       throw new NotionMCPError(
@@ -342,7 +343,7 @@ async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePage
   const updates: any = {}
 
   // Update metadata
-  if (input.icon) updates.icon = { type: 'emoji', emoji: input.icon }
+  if (input.icon) updates.icon = formatIcon(input.icon)
   if (input.cover) {
     if (!isSafeUrl(input.cover)) {
       throw new NotionMCPError(

--- a/src/tools/helpers/icons.test.ts
+++ b/src/tools/helpers/icons.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { formatIcon } from './icons'
+
+describe('formatIcon', () => {
+  describe('emoji icons', () => {
+    it('wraps a single emoji as emoji type', () => {
+      expect(formatIcon('🚀')).toEqual({ type: 'emoji', emoji: '🚀' })
+    })
+
+    it('wraps a flag emoji as emoji type', () => {
+      expect(formatIcon('🇩🇪')).toEqual({ type: 'emoji', emoji: '🇩🇪' })
+    })
+
+    it('wraps a simple text emoji', () => {
+      expect(formatIcon('📋')).toEqual({ type: 'emoji', emoji: '📋' })
+    })
+  })
+
+  describe('external URL icons', () => {
+    it('wraps an https URL as external type', () => {
+      expect(formatIcon('https://example.com/logo.png')).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/logo.png' }
+      })
+    })
+
+    it('wraps an http URL as external type', () => {
+      expect(formatIcon('http://example.com/icon.svg')).toEqual({
+        type: 'external',
+        external: { url: 'http://example.com/icon.svg' }
+      })
+    })
+  })
+
+  describe('Notion built-in icon shorthand', () => {
+    it('expands name:color to Notion icon URL', () => {
+      expect(formatIcon('document:gray')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/document_gray.svg' }
+      })
+    })
+
+    it('expands with different colors', () => {
+      expect(formatIcon('helm:blue')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/helm_blue.svg' }
+      })
+    })
+
+    it('expands lightgray color', () => {
+      expect(formatIcon('star:lightgray')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/star_lightgray.svg' }
+      })
+    })
+
+    it('does not treat a colon in a URL as icon shorthand', () => {
+      expect(formatIcon('https://example.com/icon:blue.svg')).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/icon:blue.svg' }
+      })
+    })
+  })
+})

--- a/src/tools/helpers/icons.ts
+++ b/src/tools/helpers/icons.ts
@@ -1,0 +1,46 @@
+/**
+ * Icon Helpers
+ * Format icon values for the Notion API
+ */
+
+const NOTION_ICON_COLORS = new Set([
+  'pink',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'brown',
+  'gray',
+  'lightgray'
+])
+
+/** Check if a string is a Notion built-in icon shorthand (e.g. "helm:blue") */
+function isNotionIconShorthand(value: string): boolean {
+  if (value.startsWith('http://') || value.startsWith('https://')) return false
+  const colonIdx = value.lastIndexOf(':')
+  if (colonIdx < 1) return false
+  const color = value.slice(colonIdx + 1)
+  return NOTION_ICON_COLORS.has(color)
+}
+
+/**
+ * Format an icon value for the Notion API.
+ * Accepts:
+ * - Emoji: "🚀" -> { type: "emoji", emoji: "🚀" }
+ * - External URL: "https://..." -> { type: "external", external: { url } }
+ * - Notion built-in shorthand: "document:gray" -> { type: "external", external: { url: "https://www.notion.so/icons/document_gray.svg" } }
+ */
+export function formatIcon(value: string): { type: string; [key: string]: any } {
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    return { type: 'external', external: { url: value } }
+  }
+  if (isNotionIconShorthand(value)) {
+    const colonIdx = value.lastIndexOf(':')
+    const name = value.slice(0, colonIdx)
+    const color = value.slice(colonIdx + 1)
+    return { type: 'external', external: { url: `https://www.notion.so/icons/${name}_${color}.svg` } }
+  }
+  return { type: 'emoji', emoji: value }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -86,7 +86,11 @@ const TOOLS = [
         parent_id: { type: 'string', description: 'Parent page or database ID' },
         properties: { type: 'object', description: 'Page properties (for database pages)' },
         property_id: { type: 'string', description: 'Property ID (for get_property action)' },
-        icon: { type: 'string', description: 'Emoji icon' },
+        icon: {
+          type: 'string',
+          description:
+            'Icon: emoji (e.g. "📋"), external URL (https://...), or built-in shorthand (name:color, e.g. "document:gray")'
+        },
         cover: { type: 'string', description: 'Cover image URL' },
         archived: { type: 'boolean', description: 'Archive status' }
       },
@@ -130,7 +134,11 @@ const TOOLS = [
         description: { type: 'string', description: 'Description' },
         properties: { type: 'object', description: 'Schema properties (for create/update data source)' },
         is_inline: { type: 'boolean', description: 'Display as inline (for create/update_database)' },
-        icon: { type: 'string', description: 'Emoji icon (for update_database)' },
+        icon: {
+          type: 'string',
+          description:
+            'Icon: emoji (e.g. "📋"), external URL (https://...), or built-in shorthand (name:color, e.g. "document:gray") (for update_database)'
+        },
         cover: { type: 'string', description: 'Cover image URL (for update_database)' },
         filters: { type: 'object', description: 'Query filters (for query action)' },
         sorts: { type: 'array', items: { type: 'object' }, description: 'Query sorts' },


### PR DESCRIPTION
Closes #5

## Summary

- Add `formatIcon()` helper in `src/tools/helpers/icons.ts` that detects emoji, external URL, and Notion built-in icon shorthand
- Replace hardcoded `{ type: 'emoji', emoji: input.icon }` in three locations:
  - `pages.ts` create action (line 175)
  - `pages.ts` update action (line 345)
  - `databases.ts` update_database action (line 638)

### Icon formats supported

| Input | Output |
|-------|--------|
| `🚀` (emoji) | `{ type: "emoji", emoji: "🚀" }` |
| `https://example.com/logo.png` | `{ type: "external", external: { url: "..." } }` |
| `document:gray` (built-in shorthand) | `{ type: "external", external: { url: "https://www.notion.so/icons/document_gray.svg" } }` |

## Test plan

### Phase 1: Unit tests (9 new tests, 963 total pass)

| Test case | Result |
|-----------|--------|
| Single emoji -> emoji type | PASS |
| Flag emoji -> emoji type | PASS |
| HTTPS URL -> external type | PASS |
| HTTP URL -> external type | PASS |
| Built-in icon shorthand (document:gray) -> expanded URL | PASS |
| Built-in with different color (helm:blue) | PASS |
| Lightgray color variant | PASS |
| Colon in URL not treated as shorthand | PASS |

### Phase 2: Integration tests against live Notion sandbox

| Test case | Result | Evidence |
|-----------|--------|----------|
| Bug confirmation: URL icon rejected | PASS (bug confirmed) | `body.icon.emoji should be "😀"...` - production MCP wraps URL as emoji |
| Emoji icon accepted (existing behavior) | PASS | Page created with rocket emoji |
| External URL format accepted by API | PASS | Pre-formatted `{ type: "external", external: { url } }` works |
