### PR TITLE
fix(markdown): add HTML comment hints for unexpanded children (#3)

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -717,6 +717,27 @@ describe('blocksToMarkdown', () => {
       const md = blocksToMarkdown(blocks)
       expect(md).toBe('<details>\n<summary>Empty toggle</summary>\n</details>')
     })
+
+    it('should add HTML comment when toggle has_children but children are not loaded', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          id: 'toggle-block-id-123',
+          type: 'toggle',
+          has_children: true,
+          toggle: {
+            rich_text: [plainRichText('Toggle with hidden content')],
+            color: 'default'
+          }
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain('<summary>Toggle with hidden content</summary>')
+      expect(md).toContain(
+        '<!-- has_children: fetch nested content with blocks tool, action: children, block_id: toggle-block-id-123 -->'
+      )
+      expect(md).toContain('</details>')
+    })
   })
 
   describe('images', () => {
@@ -897,6 +918,63 @@ describe('blocksToMarkdown', () => {
       expect(md).toContain(':::column')
       expect(md).toContain('Left')
       expect(md).toContain('Right')
+      expect(md).toContain(':::end')
+    })
+
+    it('should add HTML comments when column_list has_children but children are not loaded', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          id: 'collist-id-123',
+          type: 'column_list',
+          has_children: true,
+          column_list: {}
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain(':::columns')
+      expect(md).toContain(
+        '<!-- has_children: fetch nested content with blocks tool, action: children, block_id: collist-id-123 -->'
+      )
+      expect(md).toContain(':::end')
+    })
+
+    it('should add HTML comments when columns have has_children but children are not loaded', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          id: 'collist-id-456',
+          type: 'column_list',
+          has_children: true,
+          column_list: {
+            children: [
+              {
+                object: 'block',
+                id: 'col1-id',
+                type: 'column',
+                has_children: true,
+                column: {}
+              },
+              {
+                object: 'block',
+                id: 'col2-id',
+                type: 'column',
+                has_children: true,
+                column: {}
+              }
+            ]
+          }
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain(':::columns')
+      expect(md).toContain(':::column')
+      expect(md).toContain(
+        '<!-- has_children: fetch nested content with blocks tool, action: children, block_id: col1-id -->'
+      )
+      expect(md).toContain(
+        '<!-- has_children: fetch nested content with blocks tool, action: children, block_id: col2-id -->'
+      )
       expect(md).toContain(':::end')
     })
   })

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -283,6 +283,10 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
         if (block.toggle.children && block.toggle.children.length > 0) {
           lines.push('')
           lines.push(blocksToMarkdown(block.toggle.children))
+        } else if (block.has_children && block.id) {
+          lines.push(
+            `<!-- has_children: fetch nested content with blocks tool, action: children, block_id: ${block.id} -->`
+          )
         }
         lines.push('</details>')
         break
@@ -320,15 +324,25 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
       case 'column_list': {
         lines.push(':::columns')
         const columns = block.column_list?.children || []
-        for (let colIdx = 0; colIdx < columns.length; colIdx++) {
-          lines.push(':::column')
-          const columnChildren = columns[colIdx].column?.children || []
-          if (columnChildren.length > 0) {
-            lines.push(blocksToMarkdown(columnChildren))
+        if (columns.length > 0) {
+          for (let colIdx = 0; colIdx < columns.length; colIdx++) {
+            lines.push(':::column')
+            const columnChildren = columns[colIdx].column?.children || []
+            if (columnChildren.length > 0) {
+              lines.push(blocksToMarkdown(columnChildren))
+            } else if (columns[colIdx].has_children && columns[colIdx].id) {
+              lines.push(
+                `<!-- has_children: fetch nested content with blocks tool, action: children, block_id: ${columns[colIdx].id} -->`
+              )
+            }
+            if (colIdx < columns.length - 1) {
+              lines.push('')
+            }
           }
-          if (colIdx < columns.length - 1) {
-            lines.push('')
-          }
+        } else if (block.has_children && block.id) {
+          lines.push(
+            `<!-- has_children: fetch nested content with blocks tool, action: children, block_id: ${block.id} -->`
+          )
         }
         lines.push(':::end')
         break


### PR DESCRIPTION
Closes #3 (partial - addresses the readback data loss; callout emoji encoding is a separate concern)

## Summary

When `blocksToMarkdown()` encounters blocks with `has_children: true` but missing/empty children arrays (as returned by the Notion API for non-inline children), it now emits an HTML comment with the block ID so agents know to fetch nested content.

**Before:** Empty toggles/columns with no indication that content exists.
**After:** HTML comment with exact API call needed to fetch the content.

### Affected block types

| Block type | Children inline? | Fix applied |
|---|---|---|
| `toggle` | No | Yes - HTML comment hint |
| `column_list` / `column` | No | Yes - HTML comment hint |
| `synced_block` | No | Not handled (block type not in switch) |
| `table` | Yes (rows inline) | Not affected |

### Example output

Toggle with unexpanded children:
```html
<details>
<summary>My Toggle</summary>
<!-- has_children: fetch nested content with blocks tool, action: children, block_id: abc123 -->
</details>
```

Column list with unexpanded columns:
```markdown
:::columns
<!-- has_children: fetch nested content with blocks tool, action: children, block_id: collist-id -->
:::end
```

## Test plan

### Phase 1: Unit tests (3 new tests, 957 total pass)

| Test case | Result |
|-----------|--------|
| Toggle with has_children but no children -> HTML comment | PASS |
| Column list with has_children but no children -> HTML comment | PASS |
| Columns with has_children but no children -> HTML comments per column | PASS |

### Phase 2: Integration test

This is a readback-only fix (output formatting). The HTML comments are generated by `blocksToMarkdown()` which is a pure function. Integration testing would require finding existing Notion pages with toggles/columns and verifying the API returns `has_children: true` without children - which is the standard API behavior documented in the Notion API docs.
