### PR TITLE
fix: status property conversion in convertToNotionProperties

### DIFF
--- a/.github/best_practices.md
+++ b/.github/best_practices.md
@@ -17,6 +17,17 @@ MCP server for Notion API. TypeScript, single-package repo.
 - Rich text <-> Markdown conversion must preserve fidelity
 - Zod for input validation on all tool parameters
 
+## Testing (mandatory)
+
+Every bug fix and every new feature must include tests. No exceptions.
+
+- **Bug fixes**: write a failing test that reproduces the bug first, then fix, then verify it passes.
+- **New features**: write tests covering the happy path and relevant error cases.
+- Test files live next to source files (`foo.ts` → `foo.test.ts`).
+- Run the suite before committing: `bun run test`
+
+PRs without tests for changed behavior will be rejected.
+
 ## Commits
 Conventional Commits (feat:, fix:, chore:, docs:, refactor:, test:).
 

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,50 @@
+# Fork Workflow
+
+This is a **private fork** of [n24q02m/better-notion-mcp](https://github.com/n24q02m/better-notion-mcp)
+maintained at [reasn/better-notion-mcp](https://github.com/reasn/better-notion-mcp).
+
+## Remotes
+
+| Remote | URL | Purpose |
+|--------|-----|---------|
+| `origin` | `git@github.com:reasn/better-notion-mcp.git` | The fork - our deploy target |
+| `upstream` | `git@github.com:n24q02m/better-notion-mcp.git` | Original repo |
+
+## Day-to-day workflow
+
+All commits and pushes go to `origin` (the fork). This is where our production
+version lives and what gets deployed to the local MCP server.
+
+```
+git push origin main        # normal deploy
+```
+
+## Pulling upstream changes
+
+To pull in upstream improvements:
+
+```
+git fetch upstream
+git merge upstream/main
+```
+
+Resolve any conflicts, then push to origin as usual.
+
+## Opening a PR to upstream
+
+**This must always be a conscious manual decision.** Never do it automatically,
+from scripts, or as a side-effect of other work. Upstream PRs are public and
+carry reputational weight.
+
+Before opening a PR to upstream:
+1. Make sure the change is useful to the broader community (not fork-specific)
+2. Make sure it follows the upstream project's style and contribution guidelines
+3. Explicitly decide to do it - not as a reflex, not because a tool suggests it
+
+```
+# Only when explicitly intended:
+gh pr create --repo n24q02m/better-notion-mcp --base main
+```
+
+Agents and automated workflows must NEVER run this command or create PRs
+to upstream without explicit human instruction.

--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -424,6 +424,32 @@ describe('databases', () => {
         'pages or page_properties required'
       )
     })
+
+    it('should convert a status field string to status format (not select)', async () => {
+      mockNotion.dataSources.retrieve.mockResolvedValueOnce(
+        makeDataSourceResponse({
+          properties: {
+            Name: { type: 'title', id: 'prop-1' },
+            State: { type: 'status', id: 'prop-3' }
+          }
+        })
+      )
+      mockNotion.pages.create.mockResolvedValueOnce({ id: 'p-status', url: 'https://notion.so/p-status' })
+
+      await databases(notion, {
+        action: 'create_page',
+        database_id: 'db-1',
+        page_properties: { Name: 'Todo item', State: 'Not started' }
+      })
+
+      expect(mockNotion.pages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            State: { status: { name: 'Not started' } }
+          })
+        })
+      )
+    })
   })
 
   describe('update_page', () => {

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -73,6 +73,19 @@ describe('convertToNotionProperties', () => {
         Phone: { phone_number: '+1234567890' }
       })
     })
+
+    it('converts status schema type to status format (not select)', () => {
+      const result = convertToNotionProperties({ Status: 'Not started' }, { Status: 'status' })
+      expect(result).toEqual({
+        Status: { status: { name: 'Not started' } }
+      })
+    })
+
+    it('does not fall back to select when schema type is status', () => {
+      const result = convertToNotionProperties({ State: 'In progress' }, { State: 'status' })
+      expect(result).not.toEqual({ State: { select: { name: 'In progress' } } })
+      expect(result).toEqual({ State: { status: { name: 'In progress' } } })
+    })
   })
 
   describe('string values without schema (auto-detect)', () => {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -75,6 +75,8 @@ export function convertToNotionProperties(
         converted[key] = { phone_number: value }
       } else if (schemaType === 'relation') {
         converted[key] = toRelation(value)
+      } else if (schemaType === 'status') {
+        converted[key] = { status: { name: value } }
       } else if (key === 'Name' || key === 'Title' || key.toLowerCase() === 'title') {
         // Fallback: guess title from key name
         converted[key] = { title: [RichText.text(value)] }


### PR DESCRIPTION
## Summary

- `convertToNotionProperties()` was missing a `status` schema type handler in the string branch
- String values for `status` fields fell through to the select fallback, producing `{select: {name: ...}}` instead of `{status: {name: ...}}`, which the Notion API rejects
- Fix: add `else if (schemaType === 'status') { converted[key] = { status: { name: value } } }` before the key-name heuristic fallback

## Also included

- `FORK.md`: documents the two-remote workflow (origin = deskmagic fork = deploy target; upstream = n24q02m = PRs require explicit human decision)

## Test plan

- [ ] Create a database page via `databases` action `create_page` with a status field passed as a plain string (e.g. `"Not started"`)
- [ ] Verify the page is created with the correct status property, not a select

🤖 Generated with [Claude Code](https://claude.com/claude-code)