### PR TITLE
fix: render callout children and child_page/child_database in markdown

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -862,6 +862,60 @@ describe('blocksToMarkdown', () => {
       const md = blocksToMarkdown(blocks)
       expect(md).toContain('[!NOTE]')
     })
+
+    it('should render callout children prefixed with > ', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          type: 'callout',
+          callout: {
+            rich_text: [plainRichText('Title')],
+            icon: { type: 'emoji', emoji: '\u2139\ufe0f' },
+            color: 'blue_background',
+            children: [
+              {
+                object: 'block',
+                type: 'paragraph',
+                paragraph: { rich_text: [plainRichText('Child content')], color: 'default' }
+              }
+            ]
+          }
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain('> [!NOTE] Title')
+      expect(md).toContain('> Child content')
+    })
+  })
+
+  describe('child_page blocks', () => {
+    it('should render child_page with its title', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          type: 'child_page',
+          child_page: { title: 'My Page' }
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain('My Page')
+      expect(md).not.toBe('')
+    })
+  })
+
+  describe('child_database blocks', () => {
+    it('should render child_database with its title', () => {
+      const blocks: NotionBlock[] = [
+        {
+          object: 'block',
+          type: 'child_database',
+          child_database: { title: 'My Database' }
+        }
+      ]
+      const md = blocksToMarkdown(blocks)
+      expect(md).toContain('My Database')
+      expect(md).not.toBe('')
+    })
   })
 
   describe('toggles', () => {

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -280,6 +280,12 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
         const calloutIcon = block.callout.icon?.emoji || ''
         const calloutType = getCalloutTypeFromIcon(calloutIcon)
         lines.push(`> [!${calloutType}] ${calloutText}`)
+        if (block.callout.children && block.callout.children.length > 0) {
+          const childMd = blocksToMarkdown(block.callout.children)
+          for (const childLine of childMd.split('\n')) {
+            lines.push(`> ${childLine}`)
+          }
+        }
         break
       }
       case 'toggle': {
@@ -346,6 +352,12 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
         break
       case 'breadcrumb':
         lines.push('[breadcrumb]')
+        break
+      case 'child_page':
+        lines.push(`**${block.child_page.title}**`)
+        break
+      case 'child_database':
+        lines.push(`**${block.child_database.title}**`)
         break
       default:
         // Unsupported block type, skip


### PR DESCRIPTION
Closes #283 (upstream).

Callout children are now recursed into (mirroring the toggle pattern). Each child line is prefixed with `> ` to stay inside the blockquote.

`child_page` and `child_database` block types are rendered as labeled lines instead of being silently dropped.