### PR TITLE
fix: resolve stale page mention titles during block reads

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -359,6 +359,81 @@ describe('blocks', () => {
     })
   })
 
+  describe('children - stale mention resolution', () => {
+    it('should resolve stale Untitled mentions by fetching page titles', async () => {
+      const staleMention = {
+        type: 'mention',
+        mention: { page: { id: 'mentioned-page-1' } },
+        plain_text: 'Untitled',
+        annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+      }
+
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [
+          {
+            id: 'block-with-mention',
+            type: 'paragraph',
+            paragraph: { rich_text: [staleMention] }
+          }
+        ],
+        next_cursor: null,
+        has_more: false
+      })
+
+      // Mock pages.retrieve for mentioned page
+      const mockPagesRetrieve = vi.fn().mockResolvedValue({
+        id: 'mentioned-page-1',
+        properties: { Name: { type: 'title', title: [{ plain_text: 'Resolved Page Title' }] } }
+      })
+      const notionWithPages = {
+        ...mockNotion,
+        pages: { retrieve: mockPagesRetrieve }
+      }
+
+      const result = await blocks(notionWithPages as any, { action: 'children', block_id: 'block-1' })
+
+      expect(result.action).toBe('children')
+      // Verify the mentioned page was fetched
+      expect(mockPagesRetrieve).toHaveBeenCalledWith({ page_id: 'mentioned-page-1' })
+      // Verify the stale mention was resolved in-place
+      expect(staleMention.plain_text).toBe('Resolved Page Title')
+    })
+
+    it('should skip mention resolution when no stale mentions', async () => {
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [
+          {
+            id: 'block-1',
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [
+                {
+                  type: 'mention',
+                  mention: { page: { id: 'page-with-title' } },
+                  plain_text: 'Already Named',
+                  annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                }
+              ]
+            }
+          }
+        ],
+        next_cursor: null,
+        has_more: false
+      })
+
+      const mockPagesRetrieve = vi.fn()
+      const notionWithPages = {
+        ...mockNotion,
+        pages: { retrieve: mockPagesRetrieve }
+      }
+
+      await blocks(notionWithPages as any, { action: 'children', block_id: 'block-1' })
+
+      // No page retrieval for mentions since none are stale
+      expect(mockPagesRetrieve).not.toHaveBeenCalled()
+    })
+  })
+
   describe('default', () => {
     it('should throw on unknown action', async () => {
       await expect(blocks(mockNotion as any, { action: 'invalid' as any, block_id: 'block-1' })).rejects.toThrow(

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -5,7 +5,7 @@
 
 import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
-import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
+import { blocksToMarkdown, collectMentionIds, markdownToBlocks, replaceMentionTitles } from '../helpers/markdown.js'
 import { autoPaginate, fetchChildrenRecursive } from '../helpers/pagination.js'
 
 export interface BlocksInput {
@@ -52,6 +52,30 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
             notion.blocks.children.list({ block_id: blockId, start_cursor: cursor, page_size: 100 })
           ) as any
         })
+
+        // Resolve stale mention titles (plain_text === 'Untitled') by batch-fetching page titles
+        const mentionIds = collectMentionIds(blocksList as any[])
+        if (mentionIds.size > 0 && mentionIds.size <= 50) {
+          const titleMap = new Map<string, string>()
+          const ids = Array.from(mentionIds)
+          for (let i = 0; i < ids.length; i += 5) {
+            const batch = ids.slice(i, i + 5)
+            const results = await Promise.allSettled(batch.map((id) => notion.pages.retrieve({ page_id: id })))
+            for (let j = 0; j < results.length; j++) {
+              if (results[j].status === 'fulfilled') {
+                const page = (results[j] as PromiseFulfilledResult<any>).value
+                const titleProp = Object.values(page.properties || {}).find((p: any) => p.type === 'title') as any
+                const title = titleProp?.title?.[0]?.plain_text
+                if (title) {
+                  titleMap.set(batch[j], title)
+                }
+              }
+            }
+          }
+          if (titleMap.size > 0) {
+            replaceMentionTitles(blocksList as any[], titleMap)
+          }
+        }
 
         const markdown = blocksToMarkdown(blocksList as any)
         return {

--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -18,6 +18,36 @@ vi.mock('../helpers/markdown.js', () => ({
   blocksToMarkdown: vi.fn((blocks: any[]) => {
     if (!blocks.length) return ''
     return '# Mock markdown'
+  }),
+  collectMentionIds: vi.fn((blocks: any[]) => {
+    const ids = new Set<string>()
+    for (const block of blocks) {
+      const data = block[block.type]
+      if (data?.rich_text) {
+        for (const rt of data.rich_text) {
+          if (rt.type === 'mention') {
+            const id = rt.mention?.page?.id || rt.mention?.database?.id
+            if (id && rt.plain_text === 'Untitled') ids.add(id)
+          }
+        }
+      }
+    }
+    return ids
+  }),
+  replaceMentionTitles: vi.fn((blocks: any[], titleMap: Map<string, string>) => {
+    for (const block of blocks) {
+      const data = block[block.type]
+      if (data?.rich_text) {
+        for (const rt of data.rich_text) {
+          if (rt.type === 'mention') {
+            const id = rt.mention?.page?.id || rt.mention?.database?.id
+            if (id && titleMap.has(id)) {
+              rt.plain_text = titleMap.get(id)!
+            }
+          }
+        }
+      }
+    }
   })
 }))
 
@@ -917,6 +947,83 @@ describe('pages', () => {
 
     it('throws without page_id or page_ids', async () => {
       await expect(pages(mockNotion as any, { action: 'duplicate' })).rejects.toThrow('page_id or page_ids required')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // get - stale mention resolution
+  // ---------------------------------------------------------------------------
+  describe('get - stale mention resolution', () => {
+    it('resolves stale Untitled mentions by fetching page titles', async () => {
+      const staleMention = {
+        type: 'mention',
+        mention: { page: { id: 'mentioned-page-id' } },
+        plain_text: 'Untitled',
+        annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+      }
+
+      mockNotion.pages.retrieve.mockImplementation(async ({ page_id }: { page_id: string }) => {
+        if (page_id === 'get-page-1') {
+          return {
+            id: 'get-page-1',
+            url: 'https://notion.so/get-page-1',
+            created_time: '2024-01-01T00:00:00.000Z',
+            last_edited_time: '2024-01-02T00:00:00.000Z',
+            archived: false,
+            properties: { Name: { type: 'title', title: [{ plain_text: 'Main Page' }] } }
+          }
+        }
+        if (page_id === 'mentioned-page-id') {
+          return {
+            id: 'mentioned-page-id',
+            properties: { Name: { type: 'title', title: [{ plain_text: 'Resolved Title' }] } }
+          }
+        }
+        throw new Error(`Unexpected page_id: ${page_id}`)
+      })
+
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [
+          {
+            id: 'block-with-mention',
+            type: 'paragraph',
+            paragraph: { rich_text: [staleMention] }
+          }
+        ],
+        next_cursor: null,
+        has_more: false
+      })
+
+      const result = (await pages(mockNotion as any, { action: 'get', page_id: 'get-page-1' })) as GetPageResult
+
+      // Verify the mentioned page was fetched to resolve its title
+      expect(mockNotion.pages.retrieve).toHaveBeenCalledWith({ page_id: 'mentioned-page-id' })
+      // Verify the main page was also fetched
+      expect(mockNotion.pages.retrieve).toHaveBeenCalledWith({ page_id: 'get-page-1' })
+      // Result should still be valid
+      expect(result.action).toBe('get')
+      expect(result.page_id).toBe('get-page-1')
+    })
+
+    it('skips mention resolution when no stale mentions exist', async () => {
+      mockNotion.pages.retrieve.mockResolvedValue({
+        id: 'page-no-mentions',
+        url: 'https://notion.so/page-no-mentions',
+        created_time: '2024-01-01T00:00:00.000Z',
+        last_edited_time: '2024-01-01T00:00:00.000Z',
+        archived: false,
+        properties: {}
+      })
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [{ id: 'b-1', type: 'paragraph', paragraph: { rich_text: [{ type: 'text', text: { content: 'Hello' } }] } }],
+        next_cursor: null,
+        has_more: false
+      })
+
+      await pages(mockNotion as any, { action: 'get', page_id: 'page-no-mentions' })
+
+      // Only the main page retrieval, no extra calls for mentions
+      expect(mockNotion.pages.retrieve).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -7,7 +7,7 @@ import type { Client } from '@notionhq/client'
 import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { formatIcon } from '../helpers/icons.js'
-import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
+import { blocksToMarkdown, collectMentionIds, markdownToBlocks, replaceMentionTitles } from '../helpers/markdown.js'
 import { autoPaginate, fetchChildrenRecursive, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
@@ -223,6 +223,31 @@ async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult
       notion.blocks.children.list({ block_id: blockId, start_cursor: cursor, page_size: 100 })
     ) as any
   })
+
+  // Resolve stale mention titles (plain_text === 'Untitled') by batch-fetching page titles
+  const mentionIds = collectMentionIds(blocks as any[])
+  if (mentionIds.size > 0 && mentionIds.size <= 50) {
+    const titleMap = new Map<string, string>()
+    const ids = Array.from(mentionIds)
+    // Fetch in batches of 5 concurrent
+    for (let i = 0; i < ids.length; i += 5) {
+      const batch = ids.slice(i, i + 5)
+      const results = await Promise.allSettled(batch.map((id) => notion.pages.retrieve({ page_id: id })))
+      for (let j = 0; j < results.length; j++) {
+        if (results[j].status === 'fulfilled') {
+          const page = (results[j] as PromiseFulfilledResult<any>).value
+          const titleProp = Object.values(page.properties || {}).find((p: any) => p.type === 'title') as any
+          const title = titleProp?.title?.[0]?.plain_text
+          if (title) {
+            titleMap.set(batch[j], title)
+          }
+        }
+      }
+    }
+    if (titleMap.size > 0) {
+      replaceMentionTitles(blocks as any[], titleMap)
+    }
+  }
 
   const markdown = blocksToMarkdown(blocks as any)
 

--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import type { NotionBlock, RichText } from './markdown'
-import { blocksToMarkdown, extractPlainText, markdownToBlocks, parseRichText } from './markdown'
+import {
+  blocksToMarkdown,
+  collectMentionIds,
+  extractPlainText,
+  markdownToBlocks,
+  parseRichText,
+  replaceMentionTitles
+} from './markdown'
 
 // ============================================================
 // Helpers
@@ -1664,5 +1671,252 @@ describe('round-trip conversion', () => {
     expect(output).toContain('- Item 2')
     expect(output).toContain('---')
     expect(output).toContain('> Quote')
+  })
+})
+
+// ============================================================
+// collectMentionIds
+// ============================================================
+
+describe('collectMentionIds', () => {
+  it('should collect page mention IDs with plain_text Untitled', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'page-aaa' } },
+              plain_text: 'Untitled',
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids).toBeInstanceOf(Set)
+    expect(ids.size).toBe(1)
+    expect(ids.has('page-aaa')).toBe(true)
+  })
+
+  it('should collect database mention IDs with plain_text Untitled', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { database: { id: 'db-bbb' } },
+              plain_text: 'Untitled',
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids.size).toBe(1)
+    expect(ids.has('db-bbb')).toBe(true)
+  })
+
+  it('should NOT collect mentions that already have a real title', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'page-ccc' } },
+              plain_text: 'My Real Page',
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids.size).toBe(0)
+  })
+
+  it('should recurse into block children', () => {
+    const blocks = [
+      {
+        type: 'toggle',
+        toggle: {
+          rich_text: [],
+          children: [
+            {
+              type: 'paragraph',
+              paragraph: {
+                rich_text: [
+                  {
+                    type: 'mention',
+                    mention: { page: { id: 'nested-page' } },
+                    plain_text: 'Untitled',
+                    annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids.size).toBe(1)
+    expect(ids.has('nested-page')).toBe(true)
+  })
+
+  it('should collect from table_row cells', () => {
+    const blocks = [
+      {
+        type: 'table_row',
+        table_row: {
+          cells: [
+            [
+              {
+                type: 'mention',
+                mention: { page: { id: 'cell-page' } },
+                plain_text: 'Untitled',
+                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              }
+            ],
+            [
+              {
+                type: 'text',
+                text: { content: 'Normal text' },
+                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              }
+            ]
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids.size).toBe(1)
+    expect(ids.has('cell-page')).toBe(true)
+  })
+
+  it('should return empty set when no stale mentions exist', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'text',
+              text: { content: 'Just plain text' },
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const ids = collectMentionIds(blocks)
+    expect(ids.size).toBe(0)
+  })
+})
+
+// ============================================================
+// replaceMentionTitles
+// ============================================================
+
+describe('replaceMentionTitles', () => {
+  it('should replace stale plain_text with resolved titles', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'page-111' } },
+              plain_text: 'Untitled',
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const titleMap = new Map([['page-111', 'Resolved Title']])
+    replaceMentionTitles(blocks, titleMap)
+    expect(blocks[0].paragraph.rich_text[0].plain_text).toBe('Resolved Title')
+  })
+
+  it('should not modify mentions whose IDs are not in the titleMap', () => {
+    const blocks = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'page-222' } },
+              plain_text: 'Untitled',
+              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+            }
+          ]
+        }
+      }
+    ]
+    const titleMap = new Map([['page-other', 'Other Title']])
+    replaceMentionTitles(blocks, titleMap)
+    expect(blocks[0].paragraph.rich_text[0].plain_text).toBe('Untitled')
+  })
+
+  it('should recurse into children', () => {
+    const blocks = [
+      {
+        type: 'toggle',
+        toggle: {
+          rich_text: [],
+          children: [
+            {
+              type: 'paragraph',
+              paragraph: {
+                rich_text: [
+                  {
+                    type: 'mention',
+                    mention: { page: { id: 'child-page' } },
+                    plain_text: 'Untitled',
+                    annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+    const titleMap = new Map([['child-page', 'Child Title']])
+    replaceMentionTitles(blocks, titleMap)
+    expect(blocks[0].toggle.children[0].paragraph.rich_text[0].plain_text).toBe('Child Title')
+  })
+
+  it('should replace in table_row cells', () => {
+    const blocks = [
+      {
+        type: 'table_row',
+        table_row: {
+          cells: [
+            [
+              {
+                type: 'mention',
+                mention: { page: { id: 'table-page' } },
+                plain_text: 'Untitled',
+                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              }
+            ]
+          ]
+        }
+      }
+    ]
+    const titleMap = new Map([['table-page', 'Table Page Title']])
+    replaceMentionTitles(blocks, titleMap)
+    expect(blocks[0].table_row.cells[0][0].plain_text).toBe('Table Page Title')
   })
 })

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -1068,3 +1068,85 @@ function createBreadcrumb(): NotionBlock {
 function isListItem(line: string): boolean {
   return BULLETED_LIST_REGEX.test(line) || NUMBERED_LIST_REGEX.test(line)
 }
+
+// ============================================================
+// Mention resolution helpers
+// ============================================================
+
+/**
+ * Walk a block tree collecting all unique page/database mention IDs
+ * that have stale plain_text ('Untitled').
+ */
+export function collectMentionIds(blocks: any[]): Set<string> {
+  const ids = new Set<string>()
+  for (const block of blocks) {
+    const blockType = block.type
+    const blockData = block[blockType]
+    if (blockData?.rich_text) {
+      for (const rt of blockData.rich_text) {
+        if (rt.type === 'mention') {
+          const id = rt.mention?.page?.id || rt.mention?.database?.id
+          if (id && rt.plain_text === 'Untitled') {
+            ids.add(id)
+          }
+        }
+      }
+    }
+    // Recurse into children
+    if (blockData?.children) {
+      for (const childId of collectMentionIds(blockData.children)) {
+        ids.add(childId)
+      }
+    }
+    // Also check table_row cells
+    if (blockType === 'table_row' && blockData?.cells) {
+      for (const cell of blockData.cells) {
+        for (const rt of cell) {
+          if (rt.type === 'mention') {
+            const id = rt.mention?.page?.id || rt.mention?.database?.id
+            if (id && rt.plain_text === 'Untitled') {
+              ids.add(id)
+            }
+          }
+        }
+      }
+    }
+  }
+  return ids
+}
+
+/**
+ * Replace stale plain_text in mention rich text elements
+ * using a pre-fetched title map.
+ */
+export function replaceMentionTitles(blocks: any[], titleMap: Map<string, string>): void {
+  for (const block of blocks) {
+    const blockType = block.type
+    const blockData = block[blockType]
+    if (blockData?.rich_text) {
+      for (const rt of blockData.rich_text) {
+        if (rt.type === 'mention') {
+          const id = rt.mention?.page?.id || rt.mention?.database?.id
+          if (id && titleMap.has(id)) {
+            rt.plain_text = titleMap.get(id)!
+          }
+        }
+      }
+    }
+    if (blockData?.children) {
+      replaceMentionTitles(blockData.children, titleMap)
+    }
+    if (blockType === 'table_row' && blockData?.cells) {
+      for (const cell of blockData.cells) {
+        for (const rt of cell) {
+          if (rt.type === 'mention') {
+            const id = rt.mention?.page?.id || rt.mention?.database?.id
+            if (id && titleMap.has(id)) {
+              rt.plain_text = titleMap.get(id)!
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #284 (upstream). When reading blocks, the MCP now detects page mentions with stale plain_text ('Untitled') and batch-resolves their current titles from the Notion API before rendering to markdown. Capped at 50 unique mentions per read to limit API calls.