### PR TITLE
feat(pages): Include icon field in pages get response

### DIFF
--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -23,6 +23,7 @@ export interface GetPageResult {
   action: 'get'
   page_id: string
   url: string
+  icon: any | null
   created_time: string
   last_edited_time: string
   archived: boolean
@@ -233,6 +234,7 @@ async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult
     action: 'get',
     page_id: page.id,
     url: page.url,
+    icon: page.icon,
     created_time: page.created_time,
     last_edited_time: page.last_edited_time,
     archived: page.archived,


### PR DESCRIPTION
The Notion API returns the icon field on page objects, but the MCP `pages get` action was dropping it.

Adds `icon` to `GetPageResult` interface and the `getPage` return value. One-line change — passes through `page.icon` from the Notion API response.

Enables downstream consumers to check page icons (type, emoji, external URL) without direct Notion API calls.