### PR TITLE
feat(blocks): add position parameter to append action (#25)

### DIFF
--- a/src/docs/blocks.md
+++ b/src/docs/blocks.md
@@ -97,6 +97,16 @@ Returns markdown of child blocks.
 {"action": "append", "block_id": "page-id", "content": "## New Section\nParagraph text"}
 ```
 
+With position — insert at the beginning:
+```json
+{"action": "append", "block_id": "page-id", "content": "First!", "position": {"type": "start"}}
+```
+
+With position — insert after a specific block:
+```json
+{"action": "append", "block_id": "page-id", "content": "Inserted after target", "position": {"type": "after_block", "after_block": {"id": "target-block-id"}}}
+```
+
 ### update
 ```json
 {"action": "update", "block_id": "block-id", "content": "Updated text"}
@@ -110,3 +120,4 @@ Returns markdown of child blocks.
 ## Parameters
 - `block_id` - Block ID (required)
 - `content` - Markdown content (for append/update)
+- `position` - Insert position (append only). Object with `type` (`"start"` or `"after_block"`). When `type` is `"after_block"`, include `after_block: {id: "block-id"}`. Omit to append at the end.

--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -138,6 +138,43 @@ describe('blocks', () => {
         'content required for append'
       )
     })
+
+    it('should pass position with type "start" to Notion API', async () => {
+      mockNotion.blocks.children.append.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'append',
+        block_id: 'block-1',
+        content: 'Hello world',
+        position: { type: 'start' }
+      } as any)
+
+      expect(result.action).toBe('append')
+      expect(result.appended_count).toBe(1)
+      expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
+        block_id: 'block-1',
+        children: expect.any(Array),
+        position: { type: 'start' }
+      })
+    })
+
+    it('should pass position with type "after_block" to Notion API', async () => {
+      mockNotion.blocks.children.append.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'append',
+        block_id: 'block-1',
+        content: 'Hello world',
+        position: { type: 'after_block', after_block: { id: 'target-block-id' } }
+      } as any)
+
+      expect(result.action).toBe('append')
+      expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
+        block_id: 'block-1',
+        children: expect.any(Array),
+        position: { type: 'after_block', after_block: { id: 'target-block-id' } }
+      })
+    })
   })
 
   describe('update', () => {

--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -142,12 +142,15 @@ describe('blocks', () => {
     it('should pass position with type "start" to Notion API', async () => {
       mockNotion.blocks.children.append.mockResolvedValue({})
 
-      const result = await blocks(mockNotion as any, {
-        action: 'append',
-        block_id: 'block-1',
-        content: 'Hello world',
-        position: { type: 'start' }
-      } as any)
+      const result = await blocks(
+        mockNotion as any,
+        {
+          action: 'append',
+          block_id: 'block-1',
+          content: 'Hello world',
+          position: { type: 'start' }
+        } as any
+      )
 
       expect(result.action).toBe('append')
       expect(result.appended_count).toBe(1)
@@ -161,12 +164,15 @@ describe('blocks', () => {
     it('should pass position with type "after_block" to Notion API', async () => {
       mockNotion.blocks.children.append.mockResolvedValue({})
 
-      const result = await blocks(mockNotion as any, {
-        action: 'append',
-        block_id: 'block-1',
-        content: 'Hello world',
-        position: { type: 'after_block', after_block: { id: 'target-block-id' } }
-      } as any)
+      const result = await blocks(
+        mockNotion as any,
+        {
+          action: 'append',
+          block_id: 'block-1',
+          content: 'Hello world',
+          position: { type: 'after_block', after_block: { id: 'target-block-id' } }
+        } as any
+      )
 
       expect(result.action).toBe('append')
       expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -12,6 +12,10 @@ export interface BlocksInput {
   action: 'get' | 'children' | 'append' | 'update' | 'delete'
   block_id: string
   content?: string // Markdown format
+  position?: {
+    type: 'start' | 'after_block' | 'end'
+    after_block?: { id: string }
+  }
 }
 
 /**
@@ -94,7 +98,8 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
         const blocksList = markdownToBlocks(input.content)
         await notion.blocks.children.append({
           block_id: input.block_id,
-          children: blocksList as any
+          children: blocksList as any,
+          ...(input.position && { position: input.position })
         })
         return {
           action: 'append',

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -184,7 +184,27 @@ const TOOLS = [
           description: 'Action to perform'
         },
         block_id: { type: 'string', description: 'Block ID' },
-        content: { type: 'string', description: 'Markdown content (for append/update)' }
+        content: { type: 'string', description: 'Markdown content (for append/update)' },
+        position: {
+          type: 'object',
+          description: 'Insert position (append only). Omit to append at end.',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['start', 'after_block'],
+              description: 'Position type: "start" for beginning, "after_block" for after a specific block'
+            },
+            after_block: {
+              type: 'object',
+              description: 'Required when type is "after_block"',
+              properties: {
+                id: { type: 'string', description: 'Block ID to insert after' }
+              },
+              required: ['id']
+            }
+          },
+          required: ['type']
+        }
       },
       required: ['action', 'block_id']
     }


### PR DESCRIPTION
## Description
Closes #25. Supersedes #17.

Exposes the Notion API's `position` parameter on the blocks `append` action, allowing callers to insert blocks at the beginning of a page or after a specific block instead of only at the end.

This is a thin pass-through — the Notion API already supports `position` on `blocks.children.append()`, we just needed to expose it through the MCP tool interface.

## Changes
- Added `position` field to `BlocksInput` interface in `blocks.ts`
- Forward `position` to Notion API call in the append case
- Added `position` property to blocks tool input schema in `registry.ts`
- Updated `blocks.md` documentation with examples for `start` and `after_block` position types

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Existing tests pass (1285 tests across 47 files)
- [x] Added new tests for the changes (2 tests: position with type "start" and type "after_block")
- [ ] Tested manually

### Unit Test Plan
1. **position type "start"**: Verify `position: { type: "start" }` is forwarded to `notion.blocks.children.append()`
2. **position type "after_block"**: Verify `position: { type: "after_block", after_block: { id: "..." } }` is forwarded correctly
3. **No position (existing test)**: Verify omitting position still works as before (append at end)

All 3 pass.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings