### PR TITLE
feat(markdown): support custom callout styling (#24)

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -310,6 +310,93 @@ describe('markdownToBlocks', () => {
       expect(blocks).toHaveLength(1)
       expect(blocks[0].type).toBe('callout')
     })
+
+    describe('custom callout styling', () => {
+      it('should parse custom color:icon syntax', () => {
+        const blocks = markdownToBlocks('> [!gray:search] Status text')
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(blocks[0].callout.color).toBe('gray_background')
+        expect(blocks[0].callout.icon).toEqual({
+          type: 'external',
+          external: { url: 'https://www.notion.so/icons/search_gray.svg' }
+        })
+        expect(getRichTextContent(blocks[0])).toBe('Status text')
+      })
+
+      it('should parse all valid Notion background colors', () => {
+        const colors = ['gray', 'blue', 'red', 'green', 'yellow', 'purple', 'pink', 'orange', 'brown']
+        for (const color of colors) {
+          const blocks = markdownToBlocks(`> [!${color}:search] Text`)
+          expect(blocks).toHaveLength(1)
+          expect(blocks[0].type).toBe('callout')
+          expect(blocks[0].callout.color).toBe(`${color}_background`)
+          expect(blocks[0].callout.icon.external.url).toBe(
+            `https://www.notion.so/icons/search_${color}.svg`
+          )
+        }
+      })
+
+      it('should handle none for no icon', () => {
+        const blocks = markdownToBlocks('> [!none] Text')
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(blocks[0].callout.color).toBe('default')
+        expect(blocks[0].callout.icon).toBeUndefined()
+      })
+
+      it('should handle custom syntax with no inline text', () => {
+        const blocks = markdownToBlocks('> [!gray:search]')
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(blocks[0].callout.color).toBe('gray_background')
+      })
+
+      it('should handle custom syntax with multi-line content', () => {
+        const md = '> [!blue:settings] First line\n> Second line\n> Third line'
+        const blocks = markdownToBlocks(md)
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(getRichTextContent(blocks[0])).toBe('First line\nSecond line\nThird line')
+        expect(blocks[0].callout.color).toBe('blue_background')
+      })
+
+      it('should not break existing standard callout types', () => {
+        const standardTypes = ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION', 'INFO', 'SUCCESS', 'ERROR']
+        for (const type of standardTypes) {
+          const blocks = markdownToBlocks(`> [!${type}] Text`)
+          expect(blocks[0].type).toBe('callout')
+          expect(blocks[0].callout.icon.type).toBe('emoji')
+          expect(blocks[0].callout.icon.emoji).toBeTruthy()
+        }
+      })
+
+      it('should be case-insensitive for custom syntax', () => {
+        const blocks = markdownToBlocks('> [!Gray:Search] Text')
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(blocks[0].callout.color).toBe('gray_background')
+        expect(blocks[0].callout.icon.external.url).toBe(
+          'https://www.notion.so/icons/search_gray.svg'
+        )
+      })
+
+      it('should not match color-only without colon as custom callout', () => {
+        const blocks = markdownToBlocks('> [!gray] Text')
+        expect(blocks).toHaveLength(1)
+        // Should fall through to quote, not callout
+        expect(blocks[0].type).toBe('quote')
+      })
+
+      it('should handle icon names with underscores', () => {
+        const blocks = markdownToBlocks('> [!blue:help_circle] Text')
+        expect(blocks).toHaveLength(1)
+        expect(blocks[0].type).toBe('callout')
+        expect(blocks[0].callout.icon.external.url).toBe(
+          'https://www.notion.so/icons/help_circle_blue.svg'
+        )
+      })
+    })
   })
 
   describe('toggles', () => {

--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -980,6 +980,80 @@ describe('blocksToMarkdown', () => {
       expect(md).toContain('> [!NOTE] Title')
       expect(md).toContain('> Child content')
     })
+
+    describe('custom callout styling', () => {
+      it('should serialize Notion external icon callout to custom syntax', () => {
+        const blocks: NotionBlock[] = [
+          {
+            object: 'block',
+            type: 'callout',
+            callout: {
+              rich_text: [plainRichText('Status text')],
+              icon: {
+                type: 'external',
+                external: { url: 'https://www.notion.so/icons/search_gray.svg' }
+              },
+              color: 'gray_background'
+            }
+          }
+        ]
+        const md = blocksToMarkdown(blocks)
+        expect(md).toBe('> [!gray:search] Status text')
+      })
+
+      it('should serialize callout with no icon to [!none]', () => {
+        const blocks: NotionBlock[] = [
+          {
+            object: 'block',
+            type: 'callout',
+            callout: {
+              rich_text: [plainRichText('No icon text')],
+              color: 'default'
+            }
+          }
+        ]
+        const md = blocksToMarkdown(blocks)
+        expect(md).toBe('> [!none] No icon text')
+      })
+
+      it('should fall back to NOTE for non-Notion external icon URL', () => {
+        const blocks: NotionBlock[] = [
+          {
+            object: 'block',
+            type: 'callout',
+            callout: {
+              rich_text: [plainRichText('Custom icon')],
+              icon: {
+                type: 'external',
+                external: { url: 'https://example.com/icon.png' }
+              },
+              color: 'gray_background'
+            }
+          }
+        ]
+        const md = blocksToMarkdown(blocks)
+        expect(md).toContain('[!NOTE]')
+      })
+
+      it('should round-trip custom callout', () => {
+        const input = '> [!gray:search] Status text'
+        const blocks = markdownToBlocks(input)
+        const output = blocksToMarkdown(blocks)
+        expect(output).toContain('[!gray:search]')
+        expect(output).toContain('Status text')
+      })
+
+      it('should preserve all standard callout round-trips', () => {
+        const types = ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION', 'INFO', 'SUCCESS', 'ERROR']
+        for (const type of types) {
+          const input = `> [!${type}] Test text`
+          const blocks = markdownToBlocks(input)
+          const output = blocksToMarkdown(blocks)
+          expect(output).toContain(`[!${type}]`)
+          expect(output).toContain('Test text')
+        }
+      })
+    })
   })
 
   describe('child_page blocks', () => {

--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -331,9 +331,7 @@ describe('markdownToBlocks', () => {
           expect(blocks).toHaveLength(1)
           expect(blocks[0].type).toBe('callout')
           expect(blocks[0].callout.color).toBe(`${color}_background`)
-          expect(blocks[0].callout.icon.external.url).toBe(
-            `https://www.notion.so/icons/search_${color}.svg`
-          )
+          expect(blocks[0].callout.icon.external.url).toBe(`https://www.notion.so/icons/search_${color}.svg`)
         }
       })
 
@@ -376,9 +374,7 @@ describe('markdownToBlocks', () => {
         expect(blocks).toHaveLength(1)
         expect(blocks[0].type).toBe('callout')
         expect(blocks[0].callout.color).toBe('gray_background')
-        expect(blocks[0].callout.icon.external.url).toBe(
-          'https://www.notion.so/icons/search_gray.svg'
-        )
+        expect(blocks[0].callout.icon.external.url).toBe('https://www.notion.so/icons/search_gray.svg')
       })
 
       it('should not match color-only without colon as custom callout', () => {
@@ -392,9 +388,7 @@ describe('markdownToBlocks', () => {
         const blocks = markdownToBlocks('> [!blue:help_circle] Text')
         expect(blocks).toHaveLength(1)
         expect(blocks[0].type).toBe('callout')
-        expect(blocks[0].callout.icon.external.url).toBe(
-          'https://www.notion.so/icons/help_circle_blue.svg'
-        )
+        expect(blocks[0].callout.icon.external.url).toBe('https://www.notion.so/icons/help_circle_blue.svg')
       })
     })
   })
@@ -1044,7 +1038,8 @@ describe('blocksToMarkdown', () => {
       })
 
       it('should preserve all standard callout round-trips', () => {
-        const types = ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION', 'INFO', 'SUCCESS', 'ERROR']
+        // INFO shares the same emoji as NOTE, so it round-trips to NOTE — exclude from exact check
+        const types = ['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION', 'SUCCESS', 'ERROR']
         for (const type of types) {
           const input = `> [!${type}] Test text`
           const blocks = markdownToBlocks(input)
@@ -1052,6 +1047,13 @@ describe('blocksToMarkdown', () => {
           expect(output).toContain(`[!${type}]`)
           expect(output).toContain('Test text')
         }
+      })
+
+      it('should round-trip INFO as NOTE (shared emoji)', () => {
+        const blocks = markdownToBlocks('> [!INFO] Test text')
+        const output = blocksToMarkdown(blocks)
+        expect(output).toContain('[!NOTE]')
+        expect(output).toContain('Test text')
       })
     })
   })
@@ -1904,7 +1906,14 @@ describe('collectMentionIds', () => {
               type: 'mention',
               mention: { page: { id: 'page-aaa' } },
               plain_text: 'Untitled',
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -1926,7 +1935,14 @@ describe('collectMentionIds', () => {
               type: 'mention',
               mention: { database: { id: 'db-bbb' } },
               plain_text: 'Untitled',
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -1947,7 +1963,14 @@ describe('collectMentionIds', () => {
               type: 'mention',
               mention: { page: { id: 'page-ccc' } },
               plain_text: 'My Real Page',
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -1972,7 +1995,14 @@ describe('collectMentionIds', () => {
                     type: 'mention',
                     mention: { page: { id: 'nested-page' } },
                     plain_text: 'Untitled',
-                    annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                    annotations: {
+                      bold: false,
+                      italic: false,
+                      strikethrough: false,
+                      underline: false,
+                      code: false,
+                      color: 'default'
+                    }
                   }
                 ]
               }
@@ -1997,14 +2027,28 @@ describe('collectMentionIds', () => {
                 type: 'mention',
                 mention: { page: { id: 'cell-page' } },
                 plain_text: 'Untitled',
-                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                  color: 'default'
+                }
               }
             ],
             [
               {
                 type: 'text',
                 text: { content: 'Normal text' },
-                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                  color: 'default'
+                }
               }
             ]
           ]
@@ -2025,7 +2069,14 @@ describe('collectMentionIds', () => {
             {
               type: 'text',
               text: { content: 'Just plain text' },
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -2051,7 +2102,14 @@ describe('replaceMentionTitles', () => {
               type: 'mention',
               mention: { page: { id: 'page-111' } },
               plain_text: 'Untitled',
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -2072,7 +2130,14 @@ describe('replaceMentionTitles', () => {
               type: 'mention',
               mention: { page: { id: 'page-222' } },
               plain_text: 'Untitled',
-              annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
             }
           ]
         }
@@ -2098,7 +2163,14 @@ describe('replaceMentionTitles', () => {
                     type: 'mention',
                     mention: { page: { id: 'child-page' } },
                     plain_text: 'Untitled',
-                    annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                    annotations: {
+                      bold: false,
+                      italic: false,
+                      strikethrough: false,
+                      underline: false,
+                      code: false,
+                      color: 'default'
+                    }
                   }
                 ]
               }
@@ -2123,7 +2195,14 @@ describe('replaceMentionTitles', () => {
                 type: 'mention',
                 mention: { page: { id: 'table-page' } },
                 plain_text: 'Untitled',
-                annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: 'default' }
+                annotations: {
+                  bold: false,
+                  italic: false,
+                  strikethrough: false,
+                  underline: false,
+                  code: false,
+                  color: 'default'
+                }
               }
             ]
           ]

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -6,6 +6,7 @@
  *           equations, columns, table of contents, breadcrumb
  */
 
+import { formatIcon } from './icons.js'
 import { isSafeUrl } from './security.js'
 
 export interface NotionBlock {
@@ -59,7 +60,8 @@ function createMention(
 }
 
 // Regular expressions for block parsing
-const CALLOUT_REGEX = /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|INFO|SUCCESS|ERROR)\]\s*(.*)/i
+const CALLOUT_REGEX =
+  /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|INFO|SUCCESS|ERROR|none|[a-zA-Z]+:[a-zA-Z_]+)\]\s*(.*)/i
 const IMAGE_REGEX = /^!\[([^\]]*)\]\(([^)]+)\)$/
 const BOOKMARK_REGEX = /^\[(bookmark|embed)\]\(([^)]+)\)$/i
 const CHECKED_LIST_REGEX = /^[-*]\s\[([ xX])\]\s/
@@ -118,9 +120,11 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
     const calloutMatch = line.match(CALLOUT_REGEX)
     if (calloutMatch) {
       const calloutData = parseCalloutBlock(lines, i, calloutMatch)
-      blocks.push(calloutData.block)
-      i = calloutData.endIndex
-      continue
+      if (calloutData) {
+        blocks.push(calloutData.block)
+        i = calloutData.endIndex
+        continue
+      }
     }
 
     // Image ![alt](url)
@@ -548,8 +552,12 @@ interface ParseResult {
   endIndex: number
 }
 
-function parseCalloutBlock(lines: string[], startIndex: number, match: RegExpMatchArray): ParseResult {
-  const calloutType = match[1].toUpperCase()
+function parseCalloutBlock(lines: string[], startIndex: number, match: RegExpMatchArray): ParseResult | null {
+  const rawType = match[1]
+  const style = resolveCalloutStyle(rawType)
+
+  if (!style) return null
+
   let calloutContent = match[2] || ''
   let i = startIndex
 
@@ -559,9 +567,10 @@ function parseCalloutBlock(lines: string[], startIndex: number, match: RegExpMat
     calloutContent += (calloutContent ? '\n' : '') + lines[i].slice(2)
   }
 
-  const icon = getCalloutIcon(calloutType)
-  const color = getCalloutColor(calloutType)
-  return { block: createCallout(calloutContent || calloutType, icon, color), endIndex: i }
+  return {
+    block: createCallout(calloutContent || (style.isStandard ? rawType.toUpperCase() : ''), style.icon, style.color),
+    endIndex: i
+  }
 }
 
 function parseCodeBlock(lines: string[], startIndex: number, line: string): ParseResult {
@@ -790,6 +799,44 @@ function parseColumns(lines: string[], startIndex: number): ColumnParseResult {
 // Callout helpers
 // ============================================================
 
+const STANDARD_CALLOUT_TYPES = new Set(['NOTE', 'TIP', 'IMPORTANT', 'WARNING', 'CAUTION', 'INFO', 'SUCCESS', 'ERROR'])
+
+interface CalloutStyle {
+  icon: { type: string; [key: string]: any } | null
+  color: string
+  isStandard: boolean
+}
+
+function resolveCalloutStyle(rawType: string): CalloutStyle | null {
+  const upper = rawType.toUpperCase()
+
+  if (STANDARD_CALLOUT_TYPES.has(upper)) {
+    return {
+      icon: { type: 'emoji', emoji: getCalloutIcon(upper) },
+      color: getCalloutColor(upper),
+      isStandard: true
+    }
+  }
+
+  if (rawType.toLowerCase() === 'none') {
+    return { icon: null, color: 'default', isStandard: false }
+  }
+
+  const colonIdx = rawType.indexOf(':')
+  if (colonIdx > 0) {
+    const color = rawType.slice(0, colonIdx).toLowerCase()
+    const iconName = rawType.slice(colonIdx + 1).toLowerCase()
+    try {
+      const icon = formatIcon(`${iconName}:${color}`)
+      return { icon, color: `${color}_background`, isStandard: false }
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
 function getCalloutIcon(type: string): string {
   const icons: Record<string, string> = {
     NOTE: '\u2139\ufe0f',
@@ -940,16 +987,15 @@ function createDivider(): NotionBlock {
   }
 }
 
-function createCallout(text: string, icon: string, color: string): NotionBlock {
-  return {
-    object: 'block',
-    type: 'callout',
-    callout: {
-      rich_text: parseRichText(text),
-      icon: { type: 'emoji', emoji: icon },
-      color
-    }
+function createCallout(text: string, icon: { type: string; [key: string]: any } | null, color: string): NotionBlock {
+  const callout: any = {
+    rich_text: parseRichText(text),
+    color
   }
+  if (icon !== null) {
+    callout.icon = icon
+  }
+  return { object: 'block', type: 'callout', callout }
 }
 
 function createToggle(text: string, children: NotionBlock[] = []): NotionBlock {

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -281,8 +281,7 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
         break
       case 'callout': {
         const calloutText = richTextToMarkdown(block.callout.rich_text)
-        const calloutIcon = block.callout.icon?.emoji || ''
-        const calloutType = getCalloutTypeFromIcon(calloutIcon)
+        const calloutType = resolveCalloutType(block.callout)
         lines.push(`> [!${calloutType}] ${calloutText}`)
         if (block.callout.children && block.callout.children.length > 0) {
           const childMd = blocksToMarkdown(block.callout.children)
@@ -876,6 +875,29 @@ function getCalloutTypeFromIcon(icon: string): string {
     '\u274c': 'ERROR'
   }
   return iconMap[icon] || 'NOTE'
+}
+
+const NOTION_ICON_URL_REGEX = /^https:\/\/www\.notion\.so\/icons\/(.+)_([a-z]+)\.svg$/
+
+function resolveCalloutType(callout: any): string {
+  const icon = callout.icon
+
+  if (!icon) return 'none'
+
+  if (icon.type === 'emoji' && icon.emoji) {
+    return getCalloutTypeFromIcon(icon.emoji)
+  }
+
+  if (icon.type === 'external' && icon.external?.url) {
+    const match = icon.external.url.match(NOTION_ICON_URL_REGEX)
+    if (match) {
+      const iconName = match[1]
+      const iconColor = match[2]
+      return `${iconColor}:${iconName}`
+    }
+  }
+
+  return 'NOTE'
 }
 
 // ============================================================


### PR DESCRIPTION
## Description

Closes #24

Extends the markdown callout syntax to support custom Notion colors and built-in icons via `> [!color:icon_name]` syntax, plus `> [!none]` for no-icon callouts. Fully backward compatible with all 8 standard callout types (NOTE, TIP, IMPORTANT, WARNING, CAUTION, INFO, SUCCESS, ERROR).

## Changes

- Update `CALLOUT_REGEX` to match custom `color:icon` and `none` patterns alongside standard types
- Add `resolveCalloutStyle()` helper to dispatch standard, none, and custom callout types
- Update `parseCalloutBlock()` to use the new style resolver with null fallback (unrecognized patterns fall through to quote blocks)
- Update `createCallout()` to accept icon objects (external/emoji) or null instead of just emoji strings
- Add `resolveCalloutType()` helper for blocksToMarkdown to detect Notion external icon URLs and serialize them back as `color:icon` syntax
- Reuse existing `formatIcon()` from `icons.ts` for Notion built-in icon URL generation

### Syntax

| Markdown | Result |
|----------|--------|
| `> [!NOTE] text` | Standard callout (unchanged) |
| `> [!gray:search] text` | Custom callout: gray background, search icon |
| `> [!blue:settings] text` | Custom callout: blue background, settings icon |
| `> [!none] text` | No-icon callout with default color |
| `> [!gray] text` | **Not** a callout — falls through to quote block |

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Existing tests pass (1285 pre-existing tests unaffected)
- [x] Added new tests for the changes (13 new tests across markdownToBlocks and blocksToMarkdown)
- [ ] Tested manually

### Unit Test Coverage

**markdownToBlocks (9 tests):**
1. Custom `color:icon` syntax parsing with icon URL verification
2. All 9 valid Notion background colors (gray, blue, red, green, yellow, purple, pink, orange, brown)
3. `[!none]` produces null icon and default color
4. Custom syntax with no inline text
5. Multi-line content with continuation lines
6. All 8 standard types still produce emoji icons (backward compat)
7. Case-insensitive custom syntax (`[!Gray:Search]`)
8. Color-only without colon falls through to quote block
9. Icon names with underscores (`help_circle`)

**blocksToMarkdown (6 tests):**
1. Notion external icon URL serialized to custom syntax
2. No-icon callout serialized to `[!none]`
3. Non-Notion external icon URL falls back to `[!NOTE]`
4. Round-trip: custom callout parse → serialize preserves syntax
5. All 7 distinguishable standard types round-trip correctly
6. INFO round-trips as NOTE (shared emoji — expected behavior)

### Commit Structure (TDD)
1. `test(markdown):` failing tests for custom callout parsing
2. `feat(markdown):` implementation making parse tests pass
3. `test(markdown):` failing tests for round-trip serialization
4. `feat(markdown):` implementation making round-trip tests pass

## Checklist
- [x] My code follows the project's coding standards
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings