### PR TITLE
feat(pages): support one-call file-based icon upload (#28)

### DIFF
--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -1102,6 +1102,202 @@ describe('pages', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // icon_file (file-based icon upload in one call)
+  // ---------------------------------------------------------------------------
+  describe('icon_file', () => {
+    const TINY_PNG_BASE64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=='
+
+    beforeEach(() => {
+      // Add fileUploads mock to the Notion client
+      ;(mockNotion as any).fileUploads = {
+        create: vi.fn().mockResolvedValue({
+          id: 'file-upload-123',
+          status: 'pending',
+          upload_url: 'https://api.notion.com/v1/file_uploads/file-upload-123/send'
+        }),
+        send: vi.fn().mockResolvedValue({ status: 'uploaded' })
+      }
+    })
+
+    describe('create with icon_file', () => {
+      it('should upload file and set as icon in one call', async () => {
+        mockNotion.pages.create.mockResolvedValue({ id: 'page-new', url: 'https://notion.so/page-new' })
+
+        const result = (await pages(mockNotion as any, {
+          action: 'create',
+          title: 'Page with Logo',
+          parent_id: 'parent-1',
+          icon_file: {
+            filename: 'logo.png',
+            content: TINY_PNG_BASE64
+          }
+        })) as CreatePageResult
+
+        expect(result.page_id).toBe('page-new')
+        expect(result.created).toBe(true)
+
+        // Verify file was uploaded via Notion's file upload API
+        expect((mockNotion as any).fileUploads.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filename: 'logo.png',
+            content_type: expect.stringContaining('image/')
+          })
+        )
+        expect((mockNotion as any).fileUploads.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            file_upload_id: 'file-upload-123'
+          })
+        )
+
+        // Verify the page was created with a file_upload icon
+        const createArgs = mockNotion.pages.create.mock.calls[0][0]
+        expect(createArgs.icon).toEqual({
+          type: 'file_upload',
+          file_upload: { id: 'file-upload-123' }
+        })
+      })
+
+      it('should use explicit content_type when provided', async () => {
+        mockNotion.pages.create.mockResolvedValue({ id: 'page-svg', url: 'https://notion.so/page-svg' })
+
+        await pages(mockNotion as any, {
+          action: 'create',
+          title: 'SVG Icon Page',
+          parent_id: 'parent-1',
+          icon_file: {
+            filename: 'logo.svg',
+            content: TINY_PNG_BASE64,
+            content_type: 'image/svg+xml'
+          }
+        })
+
+        expect((mockNotion as any).fileUploads.create).toHaveBeenCalledWith(
+          expect.objectContaining({ content_type: 'image/svg+xml' })
+        )
+      })
+
+      it('should still work with emoji icon (no regression)', async () => {
+        mockNotion.pages.create.mockResolvedValue({ id: 'page-emoji', url: 'https://notion.so/page-emoji' })
+
+        await pages(mockNotion as any, {
+          action: 'create',
+          title: 'Emoji Page',
+          parent_id: 'parent-1',
+          icon: '🚀'
+        })
+
+        const createArgs = mockNotion.pages.create.mock.calls[0][0]
+        expect(createArgs.icon).toEqual({ type: 'emoji', emoji: '🚀' })
+        expect((mockNotion as any).fileUploads.create).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('update with icon_file', () => {
+      it('should upload file and set as icon on existing page', async () => {
+        mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
+
+        const result = (await pages(mockNotion as any, {
+          action: 'update',
+          page_id: 'page-1',
+          icon_file: {
+            filename: 'company-logo.png',
+            content: TINY_PNG_BASE64
+          }
+        })) as UpdatePageResult
+
+        expect(result).toEqual({ action: 'update', page_id: 'page-1', updated: true })
+
+        // Verify upload happened
+        expect((mockNotion as any).fileUploads.create).toHaveBeenCalled()
+        expect((mockNotion as any).fileUploads.send).toHaveBeenCalled()
+
+        // Verify page was updated with file_upload icon
+        expect(mockNotion.pages.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            page_id: 'page-1',
+            icon: { type: 'file_upload', file_upload: { id: 'file-upload-123' } }
+          })
+        )
+      })
+
+      it('should prefer icon_file over icon when both provided', async () => {
+        mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
+
+        await pages(mockNotion as any, {
+          action: 'update',
+          page_id: 'page-1',
+          icon: '🚀',
+          icon_file: {
+            filename: 'logo.png',
+            content: TINY_PNG_BASE64
+          }
+        })
+
+        // icon_file should win — the page gets a file_upload icon, not emoji
+        const updateArgs = mockNotion.pages.update.mock.calls[0][0]
+        expect(updateArgs.icon).toEqual({
+          type: 'file_upload',
+          file_upload: { id: 'file-upload-123' }
+        })
+      })
+
+      it('should combine icon_file with other updates', async () => {
+        mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
+
+        await pages(mockNotion as any, {
+          action: 'update',
+          page_id: 'page-1',
+          title: 'Renamed Page',
+          icon_file: {
+            filename: 'logo.png',
+            content: TINY_PNG_BASE64
+          }
+        })
+
+        const updateArgs = mockNotion.pages.update.mock.calls[0][0]
+        expect(updateArgs.icon).toEqual({
+          type: 'file_upload',
+          file_upload: { id: 'file-upload-123' }
+        })
+        expect(updateArgs.properties).toBeDefined()
+      })
+    })
+
+    describe('validation', () => {
+      it('should throw when icon_file has no filename', async () => {
+        await expect(
+          pages(mockNotion as any, {
+            action: 'update',
+            page_id: 'page-1',
+            icon_file: { content: TINY_PNG_BASE64 } as any
+          })
+        ).rejects.toThrow()
+      })
+
+      it('should throw when icon_file has no content', async () => {
+        await expect(
+          pages(mockNotion as any, {
+            action: 'update',
+            page_id: 'page-1',
+            icon_file: { filename: 'logo.png' } as any
+          })
+        ).rejects.toThrow()
+      })
+
+      it('should throw when icon_file content is not valid base64', async () => {
+        await expect(
+          pages(mockNotion as any, {
+            action: 'update',
+            page_id: 'page-1',
+            icon_file: { filename: 'logo.png', content: '!!!not-base64!!!' }
+          })
+        ).rejects.toThrow()
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // unknown action
   // ---------------------------------------------------------------------------
   describe('unknown action', () => {

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -7,6 +7,7 @@ import type { Client } from '@notionhq/client'
 import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { formatIcon } from '../helpers/icons.js'
+import { isValidBase64 } from '../helpers/id.js'
 import { blocksToMarkdown, collectMentionIds, markdownToBlocks, replaceMentionTitles } from '../helpers/markdown.js'
 import { autoPaginate, fetchChildrenRecursive, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
@@ -89,6 +90,11 @@ export interface PagesInput {
   parent_id?: string
   properties?: Record<string, any>
   icon?: string
+  icon_file?: {
+    filename: string
+    content: string // Base64-encoded file content
+    content_type?: string // MIME type, inferred from filename if omitted
+  }
   cover?: string
 
   // get_property params
@@ -136,6 +142,70 @@ export async function pages(notion: Client, input: PagesInput): Promise<PagesRes
   })()
 }
 
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp'
+}
+
+/**
+ * Upload a file and return a file_upload icon object for the Notion API.
+ * Handles the full create → send flow internally.
+ */
+async function uploadIconFile(
+  notion: Client,
+  iconFile: NonNullable<PagesInput['icon_file']>
+): Promise<{ type: string; file_upload: { id: string } }> {
+  if (!iconFile.filename) {
+    throw new NotionMCPError(
+      'icon_file.filename is required',
+      'VALIDATION_ERROR',
+      'Provide a filename for the icon file (e.g. "logo.png")'
+    )
+  }
+  if (!iconFile.content) {
+    throw new NotionMCPError(
+      'icon_file.content is required',
+      'VALIDATION_ERROR',
+      'Provide base64-encoded file content for the icon'
+    )
+  }
+  if (!isValidBase64(iconFile.content)) {
+    throw new NotionMCPError(
+      'icon_file.content is not valid base64',
+      'VALIDATION_ERROR',
+      'Encode the file as base64 first'
+    )
+  }
+
+  // Infer content_type from filename extension if not provided
+  const contentType =
+    iconFile.content_type ||
+    EXTENSION_MIME_TYPES[iconFile.filename.split('.').pop()?.toLowerCase() || ''] ||
+    'application/octet-stream'
+
+  // Step 1: Create file upload session
+  const upload: any = await (notion as any).fileUploads.create({
+    filename: iconFile.filename,
+    content_type: contentType
+  })
+
+  // Step 2: Send file content
+  const fileBuffer = Buffer.from(iconFile.content, 'base64')
+  const blob = new Blob([fileBuffer], { type: contentType })
+  await (notion as any).fileUploads.send({
+    file_upload_id: upload.id,
+    file: { data: blob, filename: iconFile.filename }
+  })
+
+  return { type: 'file_upload', file_upload: { id: upload.id } }
+}
+
 /**
  * Create page with title and content
  * Maps to: POST /v1/pages + PATCH /v1/blocks/{id}/children
@@ -175,7 +245,11 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
   }
 
   const pageData: any = { parent, properties }
-  if (input.icon) pageData.icon = formatIcon(input.icon)
+  if (input.icon_file) {
+    pageData.icon = await uploadIconFile(notion, input.icon_file)
+  } else if (input.icon) {
+    pageData.icon = formatIcon(input.icon)
+  }
   if (input.cover) pageData.cover = formatCover(input.cover)
 
   const page = await notion.pages.create(pageData)
@@ -370,7 +444,11 @@ async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePage
   const updates: any = {}
 
   // Update metadata
-  if (input.icon) updates.icon = formatIcon(input.icon)
+  if (input.icon_file) {
+    updates.icon = await uploadIconFile(notion, input.icon_file)
+  } else if (input.icon) {
+    updates.icon = formatIcon(input.icon)
+  }
   if (input.cover) updates.cover = formatCover(input.cover)
   if (input.archived !== undefined) updates.archived = input.archived
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -91,6 +91,16 @@ const TOOLS = [
           description:
             'Icon: emoji (e.g. "📋"), external URL (https://...), or built-in shorthand (name:color, e.g. "document:gray")'
         },
+        icon_file: {
+          type: 'object',
+          description: 'Upload a file as page icon (one call). Overrides icon if both provided.',
+          properties: {
+            filename: { type: 'string', description: 'Filename with extension (e.g. "logo.png")' },
+            content: { type: 'string', description: 'Base64-encoded file content' },
+            content_type: { type: 'string', description: 'MIME type (optional, inferred from filename)' }
+          },
+          required: ['filename', 'content']
+        },
         cover: {
           type: 'string',
           description:


### PR DESCRIPTION
## Summary

- Adds `icon_file` parameter to `pages create` and `pages update` that uploads a file and sets it as the page icon in **one MCP call**
- Agents no longer need to interact with the `file_uploads` tool separately for icon uploads
- `icon_file` takes precedence over `icon` when both are provided
- Existing icon formats (emoji, URL, built-in shorthand) are unchanged

Closes #28

## Changes Made

- `src/tools/composite/pages.ts`: Add `icon_file` to `PagesInput`, add `uploadIconFile()` helper that orchestrates `fileUploads.create` + `fileUploads.send`, wire into `createPage` and `updatePage`
- `src/tools/registry.ts`: Add `icon_file` object property to pages tool schema
- `src/tools/composite/pages.test.ts`: Add 8 tests covering happy path, precedence, validation

## Testing

### Unit Tests (8 new, all pass)

**Create with icon_file:**
- Upload file and set as icon in one call
- Use explicit content_type when provided
- Emoji icon still works (no regression)

**Update with icon_file:**
- Upload file and set as icon on existing page
- icon_file takes precedence over icon when both provided
- Combines with other metadata updates

**Validation:**
- Throws when filename missing
- Throws when content missing
- Throws when content is not valid base64

### Integration tests against live Notion

Still needed (Phase 2).

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] New tests added and passing
- [x] `bun run test` passes (1309/1309)
- [x] Biome check passes on changed files (pre-existing issues on main only)
- [x] No new TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)