### PR TITLE
fix: render page mentions in richTextToMarkdown for round-trip fidelity

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -1842,7 +1842,159 @@ describe('richTextToMarkdown mention handling', () => {
       }
     ]
     const result = blocksToMarkdown(blocks)
-    expect(result).toContain('My Database')
+    expect(result).toBe('@[My Database](db123)')
+  })
+
+  it('should apply bold annotation to page mention', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'abc123' } },
+              plain_text: 'My Page',
+              href: 'https://www.notion.so/abc123',
+              annotations: {
+                bold: true,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('**@[My Page](abc123)**')
+  })
+
+  it('should apply multiple annotations to mention', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'abc123' } },
+              plain_text: 'My Page',
+              href: 'https://www.notion.so/abc123',
+              annotations: {
+                bold: true,
+                italic: true,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('***@[My Page](abc123)***')
+  })
+
+  it('should apply code annotation to mention', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'abc123' } },
+              plain_text: 'My Page',
+              href: 'https://www.notion.so/abc123',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: true,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('`@[My Page](abc123)`')
+  })
+
+  it('should fallback to plain_text for user mention', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { type: 'user', user: { id: 'user-123', name: 'John' } },
+              plain_text: 'John Doe',
+              href: null,
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('John Doe')
+  })
+
+  it('should fallback to plain_text for date mention', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { type: 'date', date: { start: '2026-01-15' } },
+              plain_text: '2026-01-15',
+              href: null,
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('2026-01-15')
+  })
+
+  it('should round-trip page mention through parseRichText and richTextToMarkdown', () => {
+    const markdown = 'See @[My Page](abc123def456) for details'
+    const blocks = markdownToBlocks(markdown)
+    const result = blocksToMarkdown(blocks)
+    expect(result).toBe(markdown)
   })
 })
 

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -545,12 +545,16 @@ function richTextToMarkdown(richText: RichText[]): string {
     if (rt.type === 'mention' && rt.mention) {
       const title = rt.plain_text || rt.text?.content || 'Untitled'
       const id = rt.mention.page?.id || rt.mention.database?.id || ''
-      if (id) {
-        result += `@[${title}](${id})`
-        continue
-      }
-      // Fallback for other mention types (user, date, etc.)
-      result += title
+      let mentionText = id ? `@[${title}](${id})` : title
+
+      // Apply annotations (same as text elements)
+      const annotations = rt.annotations || ({} as any)
+      if (annotations.bold) mentionText = `**${mentionText}**`
+      if (annotations.italic) mentionText = `*${mentionText}*`
+      if (annotations.code) mentionText = `\`${mentionText}\``
+      if (annotations.strikethrough) mentionText = `~~${mentionText}~~`
+
+      result += mentionText
       continue
     }
 


### PR DESCRIPTION
## Summary

Closes #1

- Apply annotations (bold, italic, code, strikethrough) to mention elements in `richTextToMarkdown()`, matching the behavior already in place for text elements. Previously, annotations on mentions were silently dropped.
- Strengthen existing database mention test assertion from `toContain` to exact `toBe` match.
- Add 6 new test cases: bold mention, multi-annotation mention, code mention, user mention fallback, date mention fallback, full round-trip (markdown -> blocks -> markdown).

## What was broken

`richTextToMarkdown()` handled mention elements correctly for basic serialization (`@[Title](id)`) but never wrapped the output in annotation markers. A bold page mention would render as `@[My Page](abc123)` instead of `**@[My Page](abc123)**`.

## Test plan

- [x] 3 annotation tests (bold, bold+italic, code) — were RED before fix, now GREEN
- [x] User mention and date mention fallback to `plain_text`
- [x] Full round-trip: `@[Title](id)` -> `parseRichText` -> `richTextToMarkdown` -> `@[Title](id)`
- [x] All 791 existing tests pass
- [x] `tsc --noEmit` clean